### PR TITLE
Fix the success response code interval

### DIFF
--- a/bridge/src/main/java/com/afollestad/bridge/Response.java
+++ b/bridge/src/main/java/com/afollestad/bridge/Response.java
@@ -70,7 +70,7 @@ public final class Response implements AsResults {
     }
 
     public boolean isSuccess() {
-        return mCode == HttpURLConnection.HTTP_OK;
+        return mCode >= 200 && mCode < 300;
     }
 
     public Response throwIfNotSuccess() throws ResponseException {


### PR DESCRIPTION
 `isSuccess()` should return true if the code is in the range [200..300), which means the request was successfully received, understood, and accepted.