### PR TITLE
Content-type header

### DIFF
--- a/src/main/java/com/afollestad/bridge/Response.java
+++ b/src/main/java/com/afollestad/bridge/Response.java
@@ -108,6 +108,7 @@ public final class Response implements AsResults, Serializable {
   public String contentType() {
     String contentType = header("Content-Type");
     if (contentType == null) contentType = header("content-type");
+    if (contentType == null) contentType = header("Content-type");
     return contentType;
   }
 


### PR DESCRIPTION
header case style is not unique. On my project my api source return as Content-type.
The server is PHP/5.3.10-1ubuntu3.26.
I add one more line to grap type correctly