### PR TITLE
Fixed issue that user-defined retry spacing was ignored

### DIFF
--- a/src/main/java/com/afollestad/bridge/RequestBuilder.java
+++ b/src/main/java/com/afollestad/bridge/RequestBuilder.java
@@ -106,6 +106,7 @@ public final class RequestBuilder implements AsResultsExceptions, Serializable {
 
   public RequestBuilder retries(int count, long retrySpacing, @Nullable RetryCallback callback) {
     this.totalRetryCount = count;
+	this.retrySpacingMs = retrySpacing;
     this.retryCallback = callback;
     return this;
   }

--- a/src/main/java/com/afollestad/bridge/RequestBuilder.java
+++ b/src/main/java/com/afollestad/bridge/RequestBuilder.java
@@ -106,7 +106,7 @@ public final class RequestBuilder implements AsResultsExceptions, Serializable {
 
   public RequestBuilder retries(int count, long retrySpacing, @Nullable RetryCallback callback) {
     this.totalRetryCount = count;
-	this.retrySpacingMs = retrySpacing;
+    this.retrySpacingMs = retrySpacing;
     this.retryCallback = callback;
     return this;
   }

--- a/src/main/java/com/afollestad/bridge/RequestBuilder.java
+++ b/src/main/java/com/afollestad/bridge/RequestBuilder.java
@@ -28,7 +28,7 @@ public final class RequestBuilder implements AsResultsExceptions, Serializable {
   int readTimeout;
   int currentRetryCount;
   int totalRetryCount;
-  int retrySpacingMs;
+  long retrySpacingMs;
   RetryCallback retryCallback;
   boolean cancellable = true;
   Object tag;


### PR DESCRIPTION
The `retrySpacing` parameter sent to the `retries()` method was ignored causing retries to happen immediately. This pull request fixes that issue.