### PR TITLE
Fixed bug that defaultHeaders get inadvertently modified leading to possible side effects in subsequent calls

### DIFF
--- a/src/main/java/com/afollestad/bridge/RequestBuilder.java
+++ b/src/main/java/com/afollestad/bridge/RequestBuilder.java
@@ -49,7 +49,7 @@ public final class RequestBuilder implements AsResultsExceptions, Serializable {
     this.url = url;
     this.method = method;
 
-    headers = cf.defaultHeaders;
+    headers = new HashMap<String, Object>(cf.defaultHeaders);
     connectTimeout = cf.connectTimeout;
     readTimeout = cf.readTimeout;
     bufferSize = cf.bufferSize;

--- a/src/main/java/com/afollestad/bridge/RequestBuilder.java
+++ b/src/main/java/com/afollestad/bridge/RequestBuilder.java
@@ -106,6 +106,7 @@ public final class RequestBuilder implements AsResultsExceptions, Serializable {
 
   public RequestBuilder retries(int count, long retrySpacing, @Nullable RetryCallback callback) {
     this.totalRetryCount = count;
+	this.retrySpacingMs = retrySpacing;
     this.retryCallback = callback;
     return this;
   }

--- a/src/main/java/com/afollestad/bridge/RequestBuilder.java
+++ b/src/main/java/com/afollestad/bridge/RequestBuilder.java
@@ -106,7 +106,7 @@ public final class RequestBuilder implements AsResultsExceptions, Serializable {
 
   public RequestBuilder retries(int count, long retrySpacing, @Nullable RetryCallback callback) {
     this.totalRetryCount = count;
-	this.retrySpacingMs = retrySpacing;
+    this.retrySpacingMs = retrySpacing;
     this.retryCallback = callback;
     return this;
   }

--- a/src/main/java/com/afollestad/bridge/RequestBuilder.java
+++ b/src/main/java/com/afollestad/bridge/RequestBuilder.java
@@ -28,7 +28,7 @@ public final class RequestBuilder implements AsResultsExceptions, Serializable {
   int readTimeout;
   int currentRetryCount;
   int totalRetryCount;
-  int retrySpacingMs;
+  long retrySpacingMs;
   RetryCallback retryCallback;
   boolean cancellable = true;
   Object tag;


### PR DESCRIPTION
The previous code _referenced_ the defaultHeaders map instead of _copying_ the contents. This means that all headers added by a call would become part of the defaultHeaders and be silently added to all subsequent calls. This can lead to very strange side effects (in my case 401 Unauthorized error due to a spurious "Authorization" header added from an unrelated call!)